### PR TITLE
Add 'check' hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,3 +14,11 @@
     language: system
     pass_filenames: true
     types: [file,python]
+-   id: pants-check
+    name: pants check
+    always_run: false
+    description: runs ./pants --no-dynamic-ui check on python files
+    entry: ./pants check
+    language: system
+    pass_filenames: true
+    types: [file,python]


### PR DESCRIPTION
Pants can run type check using mypy through the 'check' target. This change brings this capability creating the pants-check hook.